### PR TITLE
fix: take browser id from second arg in session handlers

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -12,8 +12,8 @@ module.exports = (hermione, options) => {
     const events = hermione.events;
     const stat = new lib.Stat();
 
-    hermione.on(events.SESSION_START, (wd, data) => stat.markStartBrowserTime(data.browserId));
-    hermione.on(events.SESSION_END, (wd, data) => stat.markEndBrowserTime(data.browserId));
+    hermione.on(events.SESSION_START, (session) => stat.markStartBrowserTime(session.browserId));
+    hermione.on(events.SESSION_END, (session) => stat.markEndBrowserTime(session.browserId));
 
     hermione.on(events.TEST_FAIL, (data) => stat.addFailed(data.browserId));
     hermione.on(events.TEST_PASS, (data) => stat.addPassed(data.browserId));

--- a/test/hermione.js
+++ b/test/hermione.js
@@ -44,14 +44,14 @@ describe('hermione', () => {
 
     it('should start browser time on "SESSION_START" event', () => {
         sandbox.stub(Stat.prototype, 'markStartBrowserTime');
-        hermione.emit(hermione.events.SESSION_START, sinon.stub(), {browserId: 'some-browser'});
+        hermione.emit(hermione.events.SESSION_START, {browserId: 'some-browser'});
 
         assert.calledWith(Stat.prototype.markStartBrowserTime, 'some-browser');
     });
 
     it('should mark browser time on "SESSION_END" event', () => {
         sandbox.stub(Stat.prototype, 'markEndBrowserTime');
-        hermione.emit(hermione.events.SESSION_END, sinon.stub(), {browserId: 'some-browser'});
+        hermione.emit(hermione.events.SESSION_END, {browserId: 'some-browser'});
 
         assert.calledWith(Stat.prototype.markEndBrowserTime, 'some-browser');
     });


### PR DESCRIPTION
it is connected with - https://github.com/gemini-testing/hermione/pull/155