### PR TITLE
FEI-15268: stat-reporter: использовать события тестов, а не события браузеров

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -22,8 +22,8 @@ module.exports = (hermione, options) => {
         });
     });
 
-    hermione.on(events.SESSION_START, (wd, data) => stat.markStartBrowserTime(data.browserId));
-    hermione.on(events.SESSION_END, (wd, data) => stat.markEndBrowserTime(data.browserId));
+    hermione.on(events.TEST_BEGIN, (data) => stat.markStartBrowserTime(data.browserId));
+    hermione.on(events.TEST_END, (data) => stat.markEndBrowserTime(data.browserId));
 
     hermione.on(events.TEST_FAIL, (data) => stat.addFailed(data.browserId));
     hermione.on(events.TEST_PASS, (data) => stat.addPassed(data.browserId));

--- a/test/hermione.js
+++ b/test/hermione.js
@@ -63,16 +63,16 @@ describe('hermione', () => {
         assert.alwaysCalledWith(cliModuleStub, commander);
     });
 
-    it('should start browser time on "SESSION_START" event', () => {
+    it('should start browser time on "TEST_BEGIN" event', () => {
         sandbox.stub(Stat.prototype, 'markStartBrowserTime');
-        hermione.emit(hermione.events.SESSION_START, sinon.stub(), {browserId: 'some-browser'});
+        hermione.emit(hermione.events.TEST_BEGIN, {browserId: 'some-browser'});
 
         assert.calledWith(Stat.prototype.markStartBrowserTime, 'some-browser');
     });
 
-    it('should mark browser time on "SESSION_END" event', () => {
+    it('should mark browser time on "TEST_END" event', () => {
         sandbox.stub(Stat.prototype, 'markEndBrowserTime');
-        hermione.emit(hermione.events.SESSION_END, sinon.stub(), {browserId: 'some-browser'});
+        hermione.emit(hermione.events.TEST_END, {browserId: 'some-browser'});
 
         assert.calledWith(Stat.prototype.markEndBrowserTime, 'some-browser');
     });


### PR DESCRIPTION
Запоминание времени длительности сессии теперь производится на событиях TEST_BEGIN и TEST_END